### PR TITLE
Regex for docstrings in comments.py. Add to multiline check in invoke.py

### DIFF
--- a/gator/comments.py
+++ b/gator/comments.py
@@ -13,6 +13,7 @@ SINGLELINECOMMENT_RE_JAVA = r"""^(?:[^"/\\]|\"(?:[^\"\\]|\\.)*
 \"|/(?:[^/"\\]|\\.)|/\"(?:[^\"\\]|\\.)*\"|\\.)*//(.*)$"""
 SINGLELINECOMMENT_RE_PYTHON = r"""^(?:[^"#\\]|\"(?:[^\"\\]|\\.)*\"|
 /(?:[^#"\\]|\\.)|/\"(?:[^\"\\]|\\.)*\"|\\.)*#(.*)$"""
+MULTILINECOMMENT_RE_PYTHON = r'""".*?\n.*?"""'
 
 
 def count_singleline_java_comment(contents):
@@ -32,5 +33,12 @@ def count_singleline_python_comment(contents):
 def count_multiline_java_comment(contents):
     """Counts the number of multiline Java comments in the code"""
     pattern = re.compile(MULTILINECOMMENT_RE, re.MULTILINE)
+    matches = pattern.findall(contents)
+    return len(matches)
+
+
+def count_multiline_python_comment(contents):
+    """Counts the number of multiline Python comments in the code"""
+    pattern = re.compile(MULTILINECOMMENT_RE_PYTHON, re.DOTALL)
     matches = pattern.findall(contents)
     return len(matches)

--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -97,15 +97,26 @@ def invoke_all_comment_checks(
                 comments.count_singleline_python_comment,
                 exact,
             )
-    # check multiple-line comments (only in Java)
+    # check multiple-line comments
     elif comment_type == MULTIPLE:
-        met_or_exceeded_count, actual_count = entities.entity_greater_than_count(
-            filecheck,
-            directory,
-            expected_count,
-            comments.count_multiline_java_comment,
-            exact,
-        )
+        #check comments in Java
+        if language == JAVA:
+            met_or_exceeded_count, actual_count = entities.entity_greater_than_count(
+                filecheck,
+                directory,
+                expected_count,
+                comments.count_multiline_java_comment,
+                exact,
+            )
+        #check comments in Python
+        if language == PYTHON:
+            met_or_exceeded_count, actual_count = entities.entity_greater_than_count(
+                filecheck,
+                directory,
+                expected_count,
+                comments.count_multiline_python_comment,
+                exact,
+            )
     # create the message and the diagnostic
     if not exact:
         message = (


### PR DESCRIPTION
I added the regex to account for the multi-line docstrings and added to the check in invoke.py but I am still unsure about naming conventions and whether or not we want a new command line argument for this check.